### PR TITLE
Redux setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "prettier": "^2.8.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-redux": "^8.0.5",
         "react-router-dom": "^6.9.0",
         "sequelize": "^6.29.3",
         "volleyball": "^1.5.1"
@@ -939,6 +940,15 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
@@ -952,14 +962,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
       "version": "18.0.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
       "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
-      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -970,7 +978,7 @@
       "version": "18.0.11",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
       "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -978,8 +986,12 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/validator": {
       "version": "13.7.14",
@@ -1364,7 +1376,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1499,8 +1510,7 @@
     "node_modules/csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -1645,30 +1655,6 @@
       "integrity": "sha512-pAMImyokbWDtnA/ufPxjQg0fYo2DDuzAlqwnDvbXqHLphe+m80eF++perYKVm8LeTuj2zUuFXC+xgSVxyoHUdg==",
       "dev": true,
       "hasInstallScript": true,
-      "dependencies": {
-        "@esbuild/android-arm": "0.17.11",
-        "@esbuild/android-arm64": "0.17.11",
-        "@esbuild/android-x64": "0.17.11",
-        "@esbuild/darwin-arm64": "0.17.11",
-        "@esbuild/darwin-x64": "0.17.11",
-        "@esbuild/freebsd-arm64": "0.17.11",
-        "@esbuild/freebsd-x64": "0.17.11",
-        "@esbuild/linux-arm": "0.17.11",
-        "@esbuild/linux-arm64": "0.17.11",
-        "@esbuild/linux-ia32": "0.17.11",
-        "@esbuild/linux-loong64": "0.17.11",
-        "@esbuild/linux-mips64el": "0.17.11",
-        "@esbuild/linux-ppc64": "0.17.11",
-        "@esbuild/linux-riscv64": "0.17.11",
-        "@esbuild/linux-s390x": "0.17.11",
-        "@esbuild/linux-x64": "0.17.11",
-        "@esbuild/netbsd-x64": "0.17.11",
-        "@esbuild/openbsd-x64": "0.17.11",
-        "@esbuild/sunos-x64": "0.17.11",
-        "@esbuild/win32-arm64": "0.17.11",
-        "@esbuild/win32-ia32": "0.17.11",
-        "@esbuild/win32-x64": "0.17.11"
-      },
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2088,6 +2074,19 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -3146,6 +3145,49 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/react-redux": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
+      "integrity": "sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8 || ^17.0 || ^18.0",
+        "@types/react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0",
+        "react-native": ">=0.59",
+        "redux": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -3295,9 +3337,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.19.1.tgz",
       "integrity": "sha512-lAbrdN7neYCg/8WaoWn/ckzCtz+jr70GFfYdlf50OF7387HTg+wiuiqJRFYawwSPpqfqDNYqK7smY/ks2iAudg==",
       "dev": true,
-      "dependencies": {
-        "fsevents": "~2.3.2"
-      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -3841,6 +3880,14 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -3885,7 +3932,6 @@
       "dev": true,
       "dependencies": {
         "esbuild": "^0.17.5",
-        "fsevents": "~2.3.2",
         "postcss": "^8.4.21",
         "resolve": "^1.22.1",
         "rollup": "^3.18.0"
@@ -4588,6 +4634,15 @@
         "@types/ms": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
@@ -4601,14 +4656,12 @@
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/react": {
       "version": "18.0.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
       "integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -4619,7 +4672,7 @@
       "version": "18.0.11",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
       "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/react": "*"
       }
@@ -4627,8 +4680,12 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/validator": {
       "version": "13.7.14",
@@ -5003,8 +5060,7 @@
     "csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "dev": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "debug": {
       "version": "4.3.4",
@@ -5431,6 +5487,21 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
     },
     "http-errors": {
       "version": "2.0.0",
@@ -6153,6 +6224,24 @@
         "scheduler": "^0.23.0"
       }
     },
+    "react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "react-redux": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.0.5.tgz",
+      "integrity": "sha512-Q2f6fCKxPFpkXt1qNRZdEDLlScsDWyrgSj0mliK59qU6W5gvBiKkdMEG2lJzhd1rCctf0hb6EtePPLZ2e0m1uw==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "@types/hoist-non-react-statics": "^3.3.1",
+        "@types/use-sync-external-store": "^0.0.3",
+        "hoist-non-react-statics": "^3.3.2",
+        "react-is": "^18.0.0",
+        "use-sync-external-store": "^1.0.0"
+      }
+    },
     "react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -6635,6 +6724,12 @@
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prettier": "^2.8.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-redux": "^8.0.5",
     "react-router-dom": "^6.9.0",
     "sequelize": "^6.29.3",
     "volleyball": "^1.5.1"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,48 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import './App.css';
-
-// testing slices
-// since this component is mostly throwaway anyway, I thought I'd run all the slices thru here to prove 'em out
-// we should delete them all later once we get started with react buildout
-import { useSelector, useDispatch } from 'react-redux';
-import {
-  testAuth,
-  selectAuth,
-  selectMeetings,
-  testMeeting,
-  selectMessages,
-  testMessages,
-  selectTags,
-  testTags,
-  selectUsers,
-  testUser,
-} from './redux/slices';
 
 function App() {
   const [count, setCount] = useState(0);
-
-  // testing slices
-  const dispatch = useDispatch();
-
-  const auth = useSelector(selectAuth);
-  const meeting = useSelector(selectMeetings);
-  const message = useSelector(selectMessages);
-  const tag = useSelector(selectTags);
-  const user = useSelector(selectUsers);
-
-  useEffect(() => {
-    dispatch(testAuth());
-    dispatch(testMeeting());
-    dispatch(testMessages());
-    dispatch(testTags());
-    dispatch(testUser());
-  }, []);
-
-  console.log('testAuth', auth);
-  console.log('testMeeting', meeting);
-  console.log('testMessages', message);
-  console.log('testTags', tag);
-  console.log('testUser', user);
 
   return (
     <div className="flex flex-col w-screen h-screen justify-center items-center text-white text-xl gap-4">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,51 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import './App.css';
+
+// testing slices
+// since this component is mostly throwaway anyway, I thought I'd run all the slices thru here to prove 'em out
+// we should delete them all later once we get started with react buildout
+import { useSelector, useDispatch } from 'react-redux';
+import {
+  testAuth,
+  selectAuth,
+  selectMeetings,
+  testMeeting,
+  selectMessages,
+  testMessages,
+  selectTags,
+  testTags,
+  selectUsers,
+  testUser,
+} from './redux/slices';
 
 function App() {
   const [count, setCount] = useState(0);
 
+  // testing slices
+  const dispatch = useDispatch();
+
+  const auth = useSelector(selectAuth);
+  const meeting = useSelector(selectMeetings);
+  const message = useSelector(selectMessages);
+  const tag = useSelector(selectTags);
+  const user = useSelector(selectUsers);
+
+  useEffect(() => {
+    dispatch(testAuth());
+    dispatch(testMeeting());
+    dispatch(testMessages());
+    dispatch(testTags());
+    dispatch(testUser());
+  }, []);
+
+  console.log('testAuth', auth);
+  console.log('testMeeting', meeting);
+  console.log('testMessages', message);
+  console.log('testTags', tag);
+  console.log('testUser', user);
+
   return (
-    <div className='flex flex-col w-screen h-screen justify-center items-center text-white text-xl gap-4'>
+    <div className="flex flex-col w-screen h-screen justify-center items-center text-white text-xl gap-4">
       <h1>Count: {count}</h1>
       <button onClick={() => setCount((prev) => prev + 2)}>Increase</button>
     </div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,18 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App'
-import './index.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+
+import App from './App';
+import store from './redux/store';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
+  </React.StrictMode>
+);

--- a/src/redux/slices/authSlice.js
+++ b/src/redux/slices/authSlice.js
@@ -1,0 +1,21 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState: {
+    token: '',
+    auth: {},
+  },
+  reducers: {
+    testAuth: (state) => {
+      // delete me
+      state.token = 'test';
+    },
+  },
+  extraReducers: (builder) => {},
+});
+
+export const { testAuth } = authSlice.actions;
+export const selectAuth = (state) => state.auth;
+export default authSlice.reducer;

--- a/src/redux/slices/index.js
+++ b/src/redux/slices/index.js
@@ -1,0 +1,13 @@
+export { default as authSlice, selectAuth, testAuth } from './authSlice';
+export {
+  default as meetingSlice,
+  selectMeetings,
+  testMeeting,
+} from './meetingSlice';
+export {
+  default as messagesSlice,
+  selectMessages,
+  testMessages,
+} from './messagesSlice';
+export { default as tagSlice, selectTags, testTags } from './tagSlice';
+export { default as userSlice, selectUsers, testUser } from './userSlice';

--- a/src/redux/slices/meetingSlice.js
+++ b/src/redux/slices/meetingSlice.js
@@ -1,0 +1,21 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const meetingSlice = createSlice({
+  name: 'meetings',
+  initialState: {
+    meetings: [],
+    meeting: {},
+  },
+  reducers: {
+    testMeeting: (state) => {
+      // delete me
+      state.meeting = { test: 'meeting' };
+    },
+  },
+  extraReducers: (builder) => {},
+});
+
+export const selectMeetings = (state) => state.meetings;
+export const { testMeeting } = meetingSlice.actions;
+export default meetingSlice.reducer;

--- a/src/redux/slices/messagesSlice.js
+++ b/src/redux/slices/messagesSlice.js
@@ -1,0 +1,20 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const messagesSlice = createSlice({
+  name: 'messages',
+  initialState: {
+    messages: [],
+    message: {},
+  },
+  reducers: {
+    testMessages: (state) => {
+      state.message = { test: 'message' };
+    },
+  },
+  extraReducers: (builder) => {},
+});
+
+export const selectMessages = (state) => state.messages;
+export const { testMessages } = messagesSlice.actions;
+export default messagesSlice.reducer;

--- a/src/redux/slices/tagSlice.js
+++ b/src/redux/slices/tagSlice.js
@@ -1,0 +1,20 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const tagSlice = createSlice({
+  name: 'tags',
+  initialState: {
+    tags: [],
+    tag: {},
+  },
+  reducers: {
+    testTags: (state) => {
+      state.tag = { test: 'tag' };
+    },
+  },
+  extraReducers: (builder) => {},
+});
+
+export const selectTags = (state) => state.tags;
+export const { testTags } = tagSlice.actions;
+export default tagSlice.reducer;

--- a/src/redux/slices/userSlice.js
+++ b/src/redux/slices/userSlice.js
@@ -1,0 +1,20 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const userSlice = createSlice({
+  name: 'users',
+  initialState: {
+    users: [],
+    user: {},
+  },
+  reducers: {
+    testUser: (state) => {
+      state.user = { test: 'user' };
+    },
+  },
+  extraReducers: (builder) => {},
+});
+
+export const selectUsers = (state) => state.users;
+export const { testUser } = userSlice.actions;
+export default userSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,0 +1,20 @@
+import { configureStore } from '@reduxjs/toolkit';
+import {
+  authSlice,
+  meetingSlice,
+  messagesSlice,
+  tagSlice,
+  userSlice,
+} from './slices';
+
+const store = configureStore({
+  reducer: {
+    auth: authSlice,
+    meetings: meetingSlice,
+    messages: messagesSlice,
+    tags: tagSlice,
+    users: userSlice,
+  },
+});
+
+export default store;


### PR DESCRIPTION
initial redux scaffolding -- created slices auth, meeting, messages, tags, and users; an index to consolidate them; and a store to publish them. Added provider to React root (also added BrowserRouter while I was at it). I left test reducers in each slice, but those can be deleted once "real" redux buildout begins.

I took the approach of running selectors & reducers through the slice index - please let me know if you'd like to see that done differently, or if you want the folders structured differently.

Installed react-redux - please remember to `npm i` after pulling dev.