### PR TITLE
Auth slice

### DIFF
--- a/server/server.cjs
+++ b/server/server.cjs
@@ -12,6 +12,9 @@ app.use(express.urlencoded({ extended: true }));
 
 app.use(volleyball);
 
+// TODO: tighten this up - all-permissive at the moment
+app.use(cors());
+
 // Start of API routes
 app.use('/api', require('./api/index.cjs'));
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,27 +1,8 @@
 import { Route, Routes } from 'react-router-dom';
-import { useState, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
 import './App.css';
 import MockResponsive from './components/MockResponsive';
 
-import { requestLogin, tryToken, selectAuth } from './redux/slices';
-
 function App() {
-  const dispatch = useDispatch();
-  const auth = useSelector(selectAuth);
-  const [count, setCount] = useState(0);
-
-  useEffect(() => {
-    dispatch(
-      requestLogin({
-        email: 'lshelton0@gmail.com',
-        password: 'BJB6qr7fdsfsd4ee4',
-      })
-    );
-  }, []);
-
-  console.log('auth:', auth);
-
   return (
     <div>
       <Routes>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,26 @@
-import { useState } from 'react';
 import { Route, Routes } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import './App.css';
 import MockResponsive from './components/MockResponsive';
 
+import { requestLogin, tryToken, selectAuth } from './redux/slices';
+
 function App() {
+  const dispatch = useDispatch();
+  const auth = useSelector(selectAuth);
   const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    dispatch(
+      requestLogin({
+        email: 'lshelton0@gmail.com',
+        password: 'BJB6qr7fdsfsd4ee4',
+      })
+    );
+  }, []);
+
+  console.log('auth:', auth);
 
   return (
     <div>

--- a/src/redux/slices/authSlice.js
+++ b/src/redux/slices/authSlice.js
@@ -64,19 +64,19 @@ const authSlice = createSlice({
   initialState: {
     token: '',
     user: {},
-    status: '',
+    isLoading: false,
     error: '',
   },
   reducers: {
     resetStatus: (state) => {
-      state.status = '';
+      state.isLoading = false;
       state.error = '';
     },
     logOut: (state) => {
       localStorage.removeItem('token');
       state.token = '';
       state.user = {};
-      state.status = '';
+      state.isLoading = false;
       state.error = '';
     },
   },
@@ -85,33 +85,33 @@ const authSlice = createSlice({
       .addCase(requestLogin.fulfilled, (state, { payload }) => {
         state.token = payload.token;
         state.user = {};
-        state.status = 'loginSuccessful';
+        state.isLoading = false;
         state.error = '';
       })
       .addCase(requestLogin.pending, (state, { payload }) => {
         state.token = '';
         state.user = {};
-        state.status = 'pendingLogin';
+        state.isLoading = true;
         state.error = '';
       })
       .addCase(requestLogin.rejected, (state, { payload }) => {
         state.token = '';
         state.user = {};
-        state.status = 'loginFailed';
+        state.isLoading = false;
         state.error = payload;
       })
       .addCase(tryToken.fulfilled, (state, { payload }) => {
         state.user = payload.data;
-        state.status = 'loginSuccessful';
+        state.isLoading = false;
         state.error = '';
         state.token = payload.token;
       })
       .addCase(tryToken.pending, (state, { payload }) => {
-        state.status = 'pendingLogin';
+        state.isLoading = true;
         state.error = '';
       })
       .addCase(tryToken.rejected, (state, { payload }) => {
-        state.status = 'loginFailed';
+        state.isLoading = false;
         state.error = payload.message || 'token failure';
       });
   },
@@ -120,6 +120,6 @@ const authSlice = createSlice({
 export const { testAuth } = authSlice.actions;
 export const selectAuth = (state) => state.auth;
 export const selectAuthStatus = (state) => {
-  return { status: state.auth.status, error: state.auth.error };
+  return { isLoading: state.auth.isLoading, error: state.auth.error };
 };
 export default authSlice.reducer;

--- a/src/redux/slices/authSlice.js
+++ b/src/redux/slices/authSlice.js
@@ -50,9 +50,8 @@ export const tryToken = createAsyncThunk(
           authorization: token,
         },
       });
-      if (data) {
-        return { data, token };
-      }
+
+      return { data, token };
     } catch (err) {
       return rejectWithValue(err);
     }
@@ -68,7 +67,7 @@ const authSlice = createSlice({
     error: '',
   },
   reducers: {
-    resetStatus: (state) => {
+    resetAuthStatus: (state) => {
       state.isLoading = false;
       state.error = '';
     },
@@ -120,7 +119,7 @@ const authSlice = createSlice({
   },
 });
 
-export const { testAuth } = authSlice.actions;
+export const { resetAuthStatus } = authSlice.actions;
 export const selectAuth = (state) => state.auth;
 export const selectAuthStatus = (state) => {
   return { isLoading: state.auth.isLoading, error: state.auth.error };

--- a/src/redux/slices/authSlice.js
+++ b/src/redux/slices/authSlice.js
@@ -1,19 +1,107 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 
+/**
+ * requestLogin accepts an object { email, password } which is used to
+ * log the user in.
+ *
+ * The returned token is placed in localStorage as well as the slice.
+ */
+export const requestLogin = createAsyncThunk(
+  'auth/requestLogin',
+  async (credentials, { rejectWithValue }) => {
+    try {
+      const { email, password } = credentials;
+      let { data } = await axios.post('/api/auth/login', { email, password });
+      localStorage.setItem('token', data.token);
+      return data;
+    } catch (err) {
+      return rejectWithValue(err.message);
+    }
+  }
+);
+
+/**
+ * tryToken takes no parameters, but it does pull token from localStorage
+ * Once verified, the user info and token are placed in slice
+ */
+export const tryToken = createAsyncThunk(
+  'attemptTokenLogin',
+  async (placeholder, { rejectWithValue }) => {
+    try {
+      const token = localStorage.getItem('token');
+
+      if (!token) return {};
+
+      const { data } = await axios.get(`/api/auth`, {
+        headers: {
+          authorization: token,
+        },
+      });
+
+      return { data, token };
+    } catch (err) {
+      return rejectWithValue(err);
+    }
+  }
+);
+
 const authSlice = createSlice({
   name: 'auth',
   initialState: {
     token: '',
-    auth: {},
+    user: {},
+    status: '',
+    error: '',
   },
   reducers: {
-    testAuth: (state) => {
-      // delete me
-      state.token = 'test';
+    resetStatus: (state) => {
+      state.status = '';
+      state.error = '';
+    },
+    logOut: (state) => {
+      localStorage.removeItem('token');
+      state.token = '';
+      state.user = {};
+      state.status = '';
+      state.error = '';
     },
   },
-  extraReducers: (builder) => {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(requestLogin.fulfilled, (state, { payload }) => {
+        state.token = payload.token;
+        state.user = {};
+        state.status = 'loginSuccessful';
+        state.error = '';
+      })
+      .addCase(requestLogin.pending, (state, { payload }) => {
+        state.token = '';
+        state.user = {};
+        state.status = 'pendingLogin';
+        state.error = '';
+      })
+      .addCase(requestLogin.rejected, (state, { payload }) => {
+        state.token = '';
+        state.user = {};
+        state.status = 'loginFailed';
+        state.error = payload;
+      })
+      .addCase(tryToken.fulfilled, (state, { payload }) => {
+        state.user = payload.data || {};
+        state.status = 'loginSuccessful';
+        state.error = '';
+        state.token = payload.token;
+      })
+      .addCase(tryToken.pending, (state, { payload }) => {
+        state.status = 'pendingLogin';
+        state.error = '';
+      })
+      .addCase(tryToken.rejected, (state, { payload }) => {
+        state.status = 'loginFailed';
+        state.error = payload.message;
+      });
+  },
 });
 
 export const { testAuth } = authSlice.actions;

--- a/src/redux/slices/authSlice.js
+++ b/src/redux/slices/authSlice.js
@@ -1,6 +1,8 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 
+const API_URL = 'http://localhost:3000/';
+
 /**
  * requestLogin accepts an object { email, password } which is used to
  * log the user in.
@@ -12,7 +14,7 @@ export const requestLogin = createAsyncThunk(
   async (credentials, { rejectWithValue }) => {
     try {
       const { email, password } = credentials;
-      let { data } = await axios.post('http://localhost:3000/api/auth/login', {
+      let { data } = await axios.post('/api/auth/login', {
         email,
         password,
       });
@@ -24,7 +26,6 @@ export const requestLogin = createAsyncThunk(
         throw new Error('Failed token creation');
       }
     } catch (err) {
-      console.error('error in requestLogin');
       return rejectWithValue(err);
     }
   }
@@ -40,20 +41,19 @@ export const tryToken = createAsyncThunk(
     try {
       const token = localStorage.getItem('token');
 
-      if (!token) throw new Error('no token in localstorage');
+      if (!token) {
+        throw new Error('No token found in localStorage');
+      }
 
-      const { data } = await axios.get(`http://localhost:3000/api/auth`, {
+      const { data } = await axios.get(`/api/auth`, {
         headers: {
           authorization: token,
         },
       });
       if (data) {
         return { data, token };
-      } else {
-        throw new Error('Failed token validation');
       }
     } catch (err) {
-      console.error('error in tryToken');
       return rejectWithValue(err);
     }
   }
@@ -111,10 +111,11 @@ const authSlice = createSlice({
         state.error = '';
       })
       .addCase(tryToken.rejected, (state, action) => {
+        console.log('action:', action);
         state.token = '';
         state.user = {};
         state.isLoading = false;
-        state.error = action.error;
+        state.error = action.payload.message;
       });
   },
 });

--- a/src/redux/slices/authSlice.js
+++ b/src/redux/slices/authSlice.js
@@ -5,17 +5,21 @@ import axios from 'axios';
  * requestLogin accepts an object { email, password } which is used to
  * log the user in.
  *
- * The returned token is placed in localStorage as well as the slice.
+ * The returned token is placed in both localStorage and the redux slice.
  */
 export const requestLogin = createAsyncThunk(
   'auth/requestLogin',
   async (credentials, { rejectWithValue }) => {
     try {
       const { email, password } = credentials;
-      let { data } = await axios.post('/api/auth/login', { email, password });
+      let { data } = await axios.post('http://localhost:3000/api/auth/login', {
+        email,
+        password,
+      });
       localStorage.setItem('token', data.token);
       return data;
     } catch (err) {
+      console.error('error in requestLogin');
       return rejectWithValue(err.message);
     }
   }
@@ -26,22 +30,24 @@ export const requestLogin = createAsyncThunk(
  * Once verified, the user info and token are placed in slice
  */
 export const tryToken = createAsyncThunk(
-  'attemptTokenLogin',
+  'tryToken',
   async (placeholder, { rejectWithValue }) => {
     try {
+      console.log('hello from tryToken');
       const token = localStorage.getItem('token');
 
       if (!token) return {};
 
-      const { data } = await axios.get(`/api/auth`, {
+      const { data } = await axios.get(`http://localhost:3000/api/auth`, {
         headers: {
           authorization: token,
         },
       });
-
+      console.log('server response from tryToken:', data);
       return { data, token };
     } catch (err) {
-      return rejectWithValue(err);
+      console.error('error in tryToken');
+      return rejectWithValue(err.message);
     }
   }
 );
@@ -106,4 +112,5 @@ const authSlice = createSlice({
 
 export const { testAuth } = authSlice.actions;
 export const selectAuth = (state) => state.auth;
+export const selectAuthStatus = (state) => state.auth.status;
 export default authSlice.reducer;

--- a/src/redux/slices/authSlice.js
+++ b/src/redux/slices/authSlice.js
@@ -25,7 +25,7 @@ export const requestLogin = createAsyncThunk(
       }
     } catch (err) {
       console.error('error in requestLogin');
-      return rejectWithValue(err.message);
+      return rejectWithValue(err);
     }
   }
 );
@@ -54,7 +54,7 @@ export const tryToken = createAsyncThunk(
       }
     } catch (err) {
       console.error('error in tryToken');
-      return rejectWithValue(err.message);
+      return rejectWithValue(err);
     }
   }
 );
@@ -94,11 +94,11 @@ const authSlice = createSlice({
         state.isLoading = true;
         state.error = '';
       })
-      .addCase(requestLogin.rejected, (state, { payload }) => {
+      .addCase(requestLogin.rejected, (state, action) => {
         state.token = '';
         state.user = {};
         state.isLoading = false;
-        state.error = payload;
+        state.error = action.error;
       })
       .addCase(tryToken.fulfilled, (state, { payload }) => {
         state.user = payload.data;
@@ -110,9 +110,11 @@ const authSlice = createSlice({
         state.isLoading = true;
         state.error = '';
       })
-      .addCase(tryToken.rejected, (state, { payload }) => {
+      .addCase(tryToken.rejected, (state, action) => {
+        state.token = '';
+        state.user = {};
         state.isLoading = false;
-        state.error = payload.message || 'token failure';
+        state.error = action.error;
       });
   },
 });

--- a/src/redux/slices/authSlice.js
+++ b/src/redux/slices/authSlice.js
@@ -98,7 +98,7 @@ const authSlice = createSlice({
         state.token = '';
         state.user = {};
         state.isLoading = false;
-        state.error = action.error;
+        state.error = action.payload.message;
       })
       .addCase(tryToken.fulfilled, (state, { payload }) => {
         state.user = payload.data;

--- a/src/redux/slices/authSlice.js
+++ b/src/redux/slices/authSlice.js
@@ -1,7 +1,7 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import axios from 'axios';
 
-const API_URL = 'http://localhost:3000/';
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 /**
  * requestLogin accepts an object { email, password } which is used to
@@ -14,7 +14,7 @@ export const requestLogin = createAsyncThunk(
   async (credentials, { rejectWithValue }) => {
     try {
       const { email, password } = credentials;
-      let { data } = await axios.post('/api/auth/login', {
+      let { data } = await axios.post(API_URL + '/api/auth/login', {
         email,
         password,
       });
@@ -45,7 +45,7 @@ export const tryToken = createAsyncThunk(
         throw new Error('No token found in localStorage');
       }
 
-      const { data } = await axios.get(`/api/auth`, {
+      const { data } = await axios.get(API_URL + '/api/auth', {
         headers: {
           authorization: token,
         },

--- a/src/redux/slices/index.js
+++ b/src/redux/slices/index.js
@@ -1,6 +1,7 @@
 export {
   default as authSlice,
   selectAuth,
+  selectAuthStatus,
   requestLogin,
   tryToken,
 } from './authSlice';

--- a/src/redux/slices/index.js
+++ b/src/redux/slices/index.js
@@ -1,4 +1,9 @@
-export { default as authSlice, selectAuth, testAuth } from './authSlice';
+export {
+  default as authSlice,
+  selectAuth,
+  requestLogin,
+  tryToken,
+} from './authSlice';
 export {
   default as meetingSlice,
   selectMeetings,

--- a/src/redux/slices/index.js
+++ b/src/redux/slices/index.js
@@ -2,6 +2,7 @@ export {
   default as authSlice,
   selectAuth,
   selectAuthStatus,
+  resetAuthStatus,
   requestLogin,
   tryToken,
 } from './authSlice';


### PR DESCRIPTION
Added auth slice w/ 2 thunks: requestLogin (generates & stores token given {email, password} and tryToken (verifies token & stores user info in auth slice)

Enabled CORS & hard-coded dev route (http://localhost:3000) - CORS will need to be refined and backend path will need to be updated (maybe placed in .env or scripted variable?) <-- UPDATE: included in latest pushes to this PR, I've set up authSlice to pull the API path from an env variable (specifically VITE_API_URL). It'll still fail-over to http://localhost:3000, but we'll all need to make use of this when writing calls to our own API so that everything holds together post-deployment.